### PR TITLE
Handle direction based on screen width

### DIFF
--- a/src/components/Home/CharacterController.vue
+++ b/src/components/Home/CharacterController.vue
@@ -73,10 +73,10 @@ export default {
     },
     touchStartHandler(event) {
       const touchPosX = event.touches[0].clientX;
-      const charPosX = this.$refs.character.$el.getBoundingClientRect().x;
+      const screenWidth = window.screen.width;
 
-      this.isLeftDown = touchPosX < charPosX;
-      this.isRightDown = touchPosX > charPosX;
+      this.isLeftDown = touchPosX < screenWidth / 2;
+      this.isRightDown = touchPosX > screenWidth / 2;
     },
     touchEndHandler() {
       this.isLeftDown = false;


### PR DESCRIPTION
# Changes
- Define character direction based on middle point of screen width instead of character position

## Old
- Left & right direction depends touch point with reference to character current position 

## New
- Left & right direction depends on touch point with reference to middle point of screen width